### PR TITLE
second try for fix attach path

### DIFF
--- a/signal-new/README.md
+++ b/signal-new/README.md
@@ -58,7 +58,7 @@ String   objectName   =    "attachments/" + String.valueOf(attachmentId);
 ...
 ```
 
-6. (Optional, if you follow the previous step) Update the test file in `service/src/test/java/org/whispersystems/textsecuregcm/tests/controllers/AttachmentControllerTest.java` 
+6. (Optional, if you follow the previous step) Update the test file in `service/src/test/java/org/whispersystems/textsecuregcm/tests/controllers/AttachmentControllerTest.java`
 
 ```
 ...
@@ -143,7 +143,7 @@ buildConfigField "String", "SIGNAL_KEY_BACKUP_URL", "\"https://domain.com\""
 
 buildConfigField "String", "UNIDENTIFIED_SENDER_TRUST_ROOT", "\"change-to-unidentified-delivery-public-key\""
 buildConfigField "String", "ZKGROUP_SERVER_PUBLIC_PARAMS", "\"change-to-zkparams-public-key\""
-        
+
 ...
 ```
 
@@ -154,6 +154,8 @@ buildConfigField "String", "ZKGROUP_SERVER_PUBLIC_PARAMS", "\"change-to-zkparams
 ```
 ...
 
+private static final String ATTACHMENT_KEY_DOWNLOAD_PATH   = "%s";
+private static final String ATTACHMENT_ID_DOWNLOAD_PATH    = "%d";
 private static final String ATTACHMENT_UPLOAD_PATH   =   "";
 
 ...


### PR DESCRIPTION
anyway, when you change upload path and dont change download path, android signal app dont work correctly. 
error related:
```
org.whispersystems.signalservice.api.push.exceptions.PushNetworkException: org.whispersystems.signalservice.api.push.exceptions.NonSuccessfulResponseCodeException: Response: Response{protocol=http/1.1, code=404, message=Not Found, url=https://domain.com/bucketname/attachments/3192673419616436186}
 at org.whispersystems.signalservice.internal.push.PushServiceSocket.downloadFromCdn(PushServiceSocket.java:962)
 at org.whispersystems.signalservice.internal.push.PushServiceSocket.retrieveAttachment(PushServiceSocket.java:569)
 at org.whispersystems.signalservice.api.SignalServiceMessageReceiver.retrieveAttachment(SignalServiceMessageReceiver.java:189)
 at org.thoughtcrime.securesms.jobs.AttachmentDownloadJob.retrieveAttachment(AttachmentDownloadJob.java:168)
 at org.thoughtcrime.securesms.jobs.AttachmentDownloadJob.doWork(AttachmentDownloadJob.java:140)
 at org.thoughtcrime.securesms.jobs.AttachmentDownloadJob.onRun(AttachmentDownloadJob.java:110)
 at org.thoughtcrime.securesms.jobs.BaseJob.run(BaseJob.java:25)
 at org.thoughtcrime.securesms.jobmanager.JobRunner.run(JobRunner.java:85)
 at org.thoughtcrime.securesms.jobmanager.JobRunner.run(JobRunner.java:48)
Caused by: org.whispersystems.signalservice.api.push.exceptions.NonSuccessfulResponseCodeException: Response: Response{protocol=http/1.1, code=404, message=Not Found, url=https://domain.com/bucketname/attachments/3192673419616436186}
 at org.whispersystems.signalservice.internal.push.PushServiceSocket.downloadFromCdn(PushServiceSocket.java:1036)
 at org.whispersystems.signalservice.internal.push.PushServiceSocket.downloadFromCdn(PushServiceSocket.java:960)
 ... 8 more

```